### PR TITLE
Removendo cotação em tempo real para as moedas 

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,5 @@
+v0.0.4
+  Removendo cotação em tempo real para as moedas (Yahoo Finanças - deprecated)
 v0.0.3
   Adicionado cotação em tempo real para as moedas
 v0.0.2

--- a/README.mkdn
+++ b/README.mkdn
@@ -44,8 +44,6 @@ dolar_americano.compra(uma_data)  # => 1.8123
 
 dolar_americano.venda(uma_data)   # => 1.813
 
-dolar_americano.compra_agora      # => 1.902
-
 euro = BrCotacao::Euro.new
 
 euro.cotacao(uma_data) # => {:compra => 2.423, :venda => 2.4242}
@@ -53,9 +51,3 @@ euro.cotacao(uma_data) # => {:compra => 2.423, :venda => 2.4242}
 euro.compra(uma_data)  # => 2.423
 
 euro.venda(uma_data)   # => 2.4242
-
-euro.compra_agora      # => 2.4039
-```
-
-## Documentação
- A documentação, atualmente, encontra-se em http://brcotacaodoc.brunovicenzo.com/

--- a/lib/brcotacao/errors.rb
+++ b/lib/brcotacao/errors.rb
@@ -33,13 +33,5 @@ module BrCotacao
 
     end
 
-    class CotacaoAgoraNaoEncontradaError < RuntimeError
-
-      def initialize(data)
-        super("A cotação não está disponível para o dia #{data.strftime('%d/%m/%Y')}, #{data.strftime('%H:%M')}.")
-      end
-
-    end
-
   end
 end

--- a/lib/brcotacao/moedas.rb
+++ b/lib/brcotacao/moedas.rb
@@ -13,7 +13,6 @@ module BrCotacao
   module Moeda
 
     FONTE_INFORMACAO            = 'http://www4.bcb.gov.br/Download/fechamento/'.freeze
-    FONTE_INFORMACAO_TEMPO_REAL = 'http://download.finance.yahoo.com/d/quotes.body?'
 
     POSICAO_CODIGO_MOEDA = 1
     POSICAO_VALOR_COMPRA = 4
@@ -50,20 +49,6 @@ module BrCotacao
       cotacoes_moeda = dados_cotacoes(data_pesquisa).detect{|dado| dado.first.eql? self.dados.codigo}
 
       cotacoes_moeda.nil? ? nil : {:compra => cotacoes_moeda[1].gsub(',', '.').to_f, :venda => cotacoes_moeda[2].gsub(',', '.').to_f}
-    end
-
-    # Devolve o valor da cotação em tempo real de acordo com o serviço do Yahoo!.
-    # É retornado um hash contendo o valor de compra da moeda e a data que foi feita a consulta (dia e horário)
-    def cotacao_agora
-      endereco             = URI.parse("#{FONTE_INFORMACAO_TEMPO_REAL}s=#{dados.simbolo}BRL=X&f=nl1d1t1")
-      conexao              = Net::HTTP.new(endereco.host)
-      resposta             = conexao.get("#{endereco.path}?#{endereco.query}")
-      raise BrCotacao::Errors::CotacaoAgoraNaoEncontradaError.new(Time.now) unless resposta.msg.eql? 'OK'
-
-      cotacao = CSV.parse(resposta.body).first
-      data = Date.strptime(cotacao[2], '%m/%d/%Y').strftime('%Y-%m-%d')
-
-      {:compra => cotacao[1].to_f, :data => Time.parse("#{data} #{cotacao[3]} -0400")}
     end
 
     private

--- a/lib/brcotacao/version.rb
+++ b/lib/brcotacao/version.rb
@@ -1,3 +1,3 @@
 module Brcotacao
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/spec/moedas/afegane_afeganist_spec.rb
+++ b/spec/moedas/afegane_afeganist_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::AfeganeAfeganist do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/ariary_madagascar_spec.rb
+++ b/spec/moedas/ariary_madagascar_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::AriaryMadagascar do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/balboa_panama_spec.rb
+++ b/spec/moedas/balboa_panama_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::BalboaPanama do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/bath_tailandia_spec.rb
+++ b/spec/moedas/bath_tailandia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::BathTailandia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/birr_etiopia_spec.rb
+++ b/spec/moedas/birr_etiopia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::BirrEtiopia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/bolivar_forte_ven_spec.rb
+++ b/spec/moedas/bolivar_forte_ven_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::BolivarForteVen do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/boliviano_bolivia_spec.rb
+++ b/spec/moedas/boliviano_bolivia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::BolivianoBolivia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/cedi_gana_spec.rb
+++ b/spec/moedas/cedi_gana_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::CediGana do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/colon_costa_rica_spec.rb
+++ b/spec/moedas/colon_costa_rica_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::ColonCostaRica do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/colon_el_salvador_spec.rb
+++ b/spec/moedas/colon_el_salvador_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::ColonElSalvador do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/cordoba_ouro_spec.rb
+++ b/spec/moedas/cordoba_ouro_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::CordobaOuro do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/coroa_dinam_dinam_spec.rb
+++ b/spec/moedas/coroa_dinam_dinam_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::CoroaDinamDinam do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/coroa_islnd_islan_spec.rb
+++ b/spec/moedas/coroa_islnd_islan_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::CoroaIslndIslan do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/coroa_norue_norue_spec.rb
+++ b/spec/moedas/coroa_norue_norue_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::CoroaNorueNorue do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/coroa_sueca_sueci_spec.rb
+++ b/spec/moedas/coroa_sueca_sueci_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::CoroaSuecaSueci do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/coroa_tcheca_spec.rb
+++ b/spec/moedas/coroa_tcheca_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::CoroaTcheca do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dalasi_gambia_spec.rb
+++ b/spec/moedas/dalasi_gambia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DalasiGambia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_argelino_spec.rb
+++ b/spec/moedas/dinar_argelino_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarArgelino do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_bahrein_spec.rb
+++ b/spec/moedas/dinar_bahrein_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarBahrein do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_iraque_spec.rb
+++ b/spec/moedas/dinar_iraque_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarIraque do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_jordania_spec.rb
+++ b/spec/moedas/dinar_jordania_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarJordania do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_kwait_spec.rb
+++ b/spec/moedas/dinar_kwait_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarKwait do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_libia_spec.rb
+++ b/spec/moedas/dinar_libia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarLibia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_macedonia_spec.rb
+++ b/spec/moedas/dinar_macedonia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarMacedonia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_servio_serv_spec.rb
+++ b/spec/moedas/dinar_servio_serv_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarServioServ do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dinar_tunisia_spec.rb
+++ b/spec/moedas/dinar_tunisia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DinarTunisia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/direito_especial_spec.rb
+++ b/spec/moedas/direito_especial_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DireitoEspecial do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dirham_emir_arabe_spec.rb
+++ b/spec/moedas/dirham_emir_arabe_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DirhamEmirArabe do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dirham_marrocos_spec.rb
+++ b/spec/moedas/dirham_marrocos_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DirhamMarrocos do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dobra_s_tome_prin_spec.rb
+++ b/spec/moedas/dobra_s_tome_prin_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DobraSTomePrin do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_australiano_spec.rb
+++ b/spec/moedas/dolar_australiano_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarAustraliano do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_bahamas_spec.rb
+++ b/spec/moedas/dolar_bahamas_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarBahamas do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_barbados_spec.rb
+++ b/spec/moedas/dolar_barbados_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarBarbados do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_belize_spec.rb
+++ b/spec/moedas/dolar_belize_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarBelize do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_bermudas_spec.rb
+++ b/spec/moedas/dolar_bermudas_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarBermudas do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_brunei_spec.rb
+++ b/spec/moedas/dolar_brunei_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarBrunei do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_canadense_spec.rb
+++ b/spec/moedas/dolar_canadense_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarCanadense do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_caribe_orie_spec.rb
+++ b/spec/moedas/dolar_caribe_orie_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarCaribeOrie do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_cayman_spec.rb
+++ b/spec/moedas/dolar_cayman_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarCayman do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_cingapura_spec.rb
+++ b/spec/moedas/dolar_cingapura_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarCingapura do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_da_guiana_spec.rb
+++ b/spec/moedas/dolar_da_guiana_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarDaGuiana do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_da_namibia_spec.rb
+++ b/spec/moedas/dolar_da_namibia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarDaNamibia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_dos_eua_spec.rb
+++ b/spec/moedas/dolar_dos_eua_spec.rb
@@ -67,8 +67,4 @@ describe BrCotacao::DolarDosEua do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_fiji_spec.rb
+++ b/spec/moedas/dolar_fiji_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarFiji do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_hong_kong_spec.rb
+++ b/spec/moedas/dolar_hong_kong_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarHongKong do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_il_salomao_spec.rb
+++ b/spec/moedas/dolar_il_salomao_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarIlSalomao do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_jamaica_spec.rb
+++ b/spec/moedas/dolar_jamaica_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarJamaica do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_liberia_spec.rb
+++ b/spec/moedas/dolar_liberia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarLiberia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_nova_zeland_spec.rb
+++ b/spec/moedas/dolar_nova_zeland_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarNovaZeland do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_ouro_spec.rb
+++ b/spec/moedas/dolar_ouro_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarOuro do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_suriname_spec.rb
+++ b/spec/moedas/dolar_suriname_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarSuriname do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_trin_tobag_spec.rb
+++ b/spec/moedas/dolar_trin_tobag_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarTrinTobag do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dolar_zimbabue_spec.rb
+++ b/spec/moedas/dolar_zimbabue_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DolarZimbabue do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dongue_vietnan_spec.rb
+++ b/spec/moedas/dongue_vietnan_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DongueVietnan do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/dram_armenia_rep_spec.rb
+++ b/spec/moedas/dram_armenia_rep_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::DramArmeniaRep do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/escudo_cabo_verde_spec.rb
+++ b/spec/moedas/escudo_cabo_verde_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::EscudoCaboVerde do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/euro_spec.rb
+++ b/spec/moedas/euro_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::Euro do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/florim_aruba_spec.rb
+++ b/spec/moedas/florim_aruba_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FlorimAruba do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/forint_hungria_spec.rb
+++ b/spec/moedas/forint_hungria_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::ForintHungria do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_burundi_spec.rb
+++ b/spec/moedas/franco_burundi_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoBurundi do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_cfa_bceao_spec.rb
+++ b/spec/moedas/franco_cfa_bceao_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoCfaBceao do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_cfa_beac_spec.rb
+++ b/spec/moedas/franco_cfa_beac_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoCfaBeac do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_cfp_spec.rb
+++ b/spec/moedas/franco_cfp_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoCfp do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_comores_spec.rb
+++ b/spec/moedas/franco_comores_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoComores do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_congoles_spec.rb
+++ b/spec/moedas/franco_congoles_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoCongoles do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_djibuti_spec.rb
+++ b/spec/moedas/franco_djibuti_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoDjibuti do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_guine_spec.rb
+++ b/spec/moedas/franco_guine_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoGuine do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_ruanda_spec.rb
+++ b/spec/moedas/franco_ruanda_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoRuanda do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/franco_suico_spec.rb
+++ b/spec/moedas/franco_suico_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::FrancoSuico do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/gourde_haiti_spec.rb
+++ b/spec/moedas/gourde_haiti_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::GourdeHaiti do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/guarani_paraguai_spec.rb
+++ b/spec/moedas/guarani_paraguai_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::GuaraniParaguai do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/guilder_antilhas_spec.rb
+++ b/spec/moedas/guilder_antilhas_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::GuilderAntilhas do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/hyrvnia_ucrania_spec.rb
+++ b/spec/moedas/hyrvnia_ucrania_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::HyrvniaUcrania do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/iene_spec.rb
+++ b/spec/moedas/iene_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::Iene do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/iuan_renmimbi_chi_spec.rb
+++ b/spec/moedas/iuan_renmimbi_chi_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::IuanRenmimbiChi do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/kina_papua_n_guin_spec.rb
+++ b/spec/moedas/kina_papua_n_guin_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::KinaPapuaNGuin do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/kuna_croacia_spec.rb
+++ b/spec/moedas/kuna_croacia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::KunaCroacia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/kwanza_angola_spec.rb
+++ b/spec/moedas/kwanza_angola_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::KwanzaAngola do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/lari_georgia_spec.rb
+++ b/spec/moedas/lari_georgia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LariGeorgia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/lat_letonia_rep_spec.rb
+++ b/spec/moedas/lat_letonia_rep_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LatLetoniaRep do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/lek_albania_rep_spec.rb
+++ b/spec/moedas/lek_albania_rep_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LekAlbaniaRep do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/lempira_honduras_spec.rb
+++ b/spec/moedas/lempira_honduras_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LempiraHonduras do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/leone_serra_leoa_spec.rb
+++ b/spec/moedas/leone_serra_leoa_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LeoneSerraLeoa do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/leu_moldavia_rep_spec.rb
+++ b/spec/moedas/leu_moldavia_rep_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LeuMoldaviaRep do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/lev_bulgaria_rep_spec.rb
+++ b/spec/moedas/lev_bulgaria_rep_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LevBulgariaRep do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/libra_egito_spec.rb
+++ b/spec/moedas/libra_egito_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LibraEgito do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/libra_esterlina_spec.rb
+++ b/spec/moedas/libra_esterlina_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LibraEsterlina do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/libra_falkland_spec.rb
+++ b/spec/moedas/libra_falkland_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LibraFalkland do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/libra_gibraltar_spec.rb
+++ b/spec/moedas/libra_gibraltar_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LibraGibraltar do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/libra_libano_spec.rb
+++ b/spec/moedas/libra_libano_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LibraLibano do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/libra_siria_rep_spec.rb
+++ b/spec/moedas/libra_siria_rep_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LibraSiriaRep do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/libra_sta_helena_spec.rb
+++ b/spec/moedas/libra_sta_helena_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LibraStaHelena do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/lilangeni_suazil_spec.rb
+++ b/spec/moedas/lilangeni_suazil_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LilangeniSuazil do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/lita_lituania_spec.rb
+++ b/spec/moedas/lita_lituania_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LitaLituania do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/loti_lesoto_spec.rb
+++ b/spec/moedas/loti_lesoto_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::LotiLesoto do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/manat_arzebaijao_spec.rb
+++ b/spec/moedas/manat_arzebaijao_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::ManatArzebaijao do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/marco_conv_bosnia_spec.rb
+++ b/spec/moedas/marco_conv_bosnia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::MarcoConvBosnia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/naira_nigeria_spec.rb
+++ b/spec/moedas/naira_nigeria_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NairaNigeria do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/nakfa_eritreia_spec.rb
+++ b/spec/moedas/nakfa_eritreia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NakfaEritreia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/ngultrum_butao_spec.rb
+++ b/spec/moedas/ngultrum_butao_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NgultrumButao do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/nova_libra_sudane_spec.rb
+++ b/spec/moedas/nova_libra_sudane_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NovaLibraSudane do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/nova_lira_turquia_spec.rb
+++ b/spec/moedas/nova_lira_turquia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NovaLiraTurquia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/nova_metical_moca_spec.rb
+++ b/spec/moedas/nova_metical_moca_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NovaMeticalMoca do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/novo_dolar_taiwan_spec.rb
+++ b/spec/moedas/novo_dolar_taiwan_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NovoDolarTaiwan do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/novo_leu_romenia_spec.rb
+++ b/spec/moedas/novo_leu_romenia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NovoLeuRomenia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/novo_manat_turcom_spec.rb
+++ b/spec/moedas/novo_manat_turcom_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NovoManatTurcom do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/novo_sol_peru_spec.rb
+++ b/spec/moedas/novo_sol_peru_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::NovoSolPeru do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/paanga_tonga_spec.rb
+++ b/spec/moedas/paanga_tonga_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PaangaTonga do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/pataca_macau_spec.rb
+++ b/spec/moedas/pataca_macau_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PatacaMacau do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_argentina_spec.rb
+++ b/spec/moedas/peso_argentina_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoArgentina do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_chile_spec.rb
+++ b/spec/moedas/peso_chile_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoChile do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_colombia_spec.rb
+++ b/spec/moedas/peso_colombia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoColombia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_cuba_spec.rb
+++ b/spec/moedas/peso_cuba_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoCuba do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_filipinas_spec.rb
+++ b/spec/moedas/peso_filipinas_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoFilipinas do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_guine_bissau_spec.rb
+++ b/spec/moedas/peso_guine_bissau_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoGuineBissau do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_mexico_spec.rb
+++ b/spec/moedas/peso_mexico_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoMexico do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_rep_dominic_spec.rb
+++ b/spec/moedas/peso_rep_dominic_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoRepDominic do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/peso_uruguaio_spec.rb
+++ b/spec/moedas/peso_uruguaio_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PesoUruguaio do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/pula_botswana_spec.rb
+++ b/spec/moedas/pula_botswana_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::PulaBotswana do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/quacha_malavi_spec.rb
+++ b/spec/moedas/quacha_malavi_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::QuachaMalavi do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/quacha_zambia_spec.rb
+++ b/spec/moedas/quacha_zambia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::QuachaZambia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/quetzal_guatemala_spec.rb
+++ b/spec/moedas/quetzal_guatemala_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::QuetzalGuatemala do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/quiate_birmania_spec.rb
+++ b/spec/moedas/quiate_birmania_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::QuiateBirmania do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/quipe_laos_rep_spec.rb
+++ b/spec/moedas/quipe_laos_rep_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::QuipeLaosRep do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rande_africa_sul_spec.rb
+++ b/spec/moedas/rande_africa_sul_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RandeAfricaSul do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/real_brasil_spec.rb
+++ b/spec/moedas/real_brasil_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RealBrasil do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rial_arab_saudita_spec.rb
+++ b/spec/moedas/rial_arab_saudita_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RialArabSaudita do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rial_catar_spec.rb
+++ b/spec/moedas/rial_catar_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RialCatar do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rial_iemen_spec.rb
+++ b/spec/moedas/rial_iemen_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RialIemen do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rial_iran_rep_spec.rb
+++ b/spec/moedas/rial_iran_rep_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RialIranRep do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rial_oma_spec.rb
+++ b/spec/moedas/rial_oma_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RialOma do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/riel_camboja_spec.rb
+++ b/spec/moedas/riel_camboja_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RielCamboja do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/ringgit_malasia_spec.rb
+++ b/spec/moedas/ringgit_malasia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RinggitMalasia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rublo_belarus_spec.rb
+++ b/spec/moedas/rublo_belarus_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RubloBelarus do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rublo_russia_spec.rb
+++ b/spec/moedas/rublo_russia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RubloRussia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rufia_maldivas_spec.rb
+++ b/spec/moedas/rufia_maldivas_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RufiaMaldivas do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rupia_india_spec.rb
+++ b/spec/moedas/rupia_india_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RupiaIndia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rupia_indonesia_spec.rb
+++ b/spec/moedas/rupia_indonesia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RupiaIndonesia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rupia_mauricio_spec.rb
+++ b/spec/moedas/rupia_mauricio_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RupiaMauricio do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rupia_nepal_spec.rb
+++ b/spec/moedas/rupia_nepal_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RupiaNepal do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rupia_paquistao_spec.rb
+++ b/spec/moedas/rupia_paquistao_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RupiaPaquistao do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rupia_seycheles_spec.rb
+++ b/spec/moedas/rupia_seycheles_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RupiaSeycheles do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/rupia_sri_lanka_spec.rb
+++ b/spec/moedas/rupia_sri_lanka_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::RupiaSriLanka do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/shekel_israel_spec.rb
+++ b/spec/moedas/shekel_israel_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::ShekelIsrael do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/som_quirguistao_spec.rb
+++ b/spec/moedas/som_quirguistao_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::SomQuirguistao do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/som_uzbequistao_spec.rb
+++ b/spec/moedas/som_uzbequistao_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::SomUzbequistao do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/somoni_tadjiquist_spec.rb
+++ b/spec/moedas/somoni_tadjiquist_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::SomoniTadjiquist do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/taca_bangladesh_spec.rb
+++ b/spec/moedas/taca_bangladesh_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::TacaBangladesh do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/tala_samoa_oc_spec.rb
+++ b/spec/moedas/tala_samoa_oc_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::TalaSamoaOc do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/tenge_cazaquistao_spec.rb
+++ b/spec/moedas/tenge_cazaquistao_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::TengeCazaquistao do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/tugrik_mongolia_spec.rb
+++ b/spec/moedas/tugrik_mongolia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::TugrikMongolia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/unid_fomento_chil_spec.rb
+++ b/spec/moedas/unid_fomento_chil_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::UnidFomentoChil do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/unid_monet_europ_spec.rb
+++ b/spec/moedas/unid_monet_europ_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::UnidMonetEurop do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/vatu_vanuatu_spec.rb
+++ b/spec/moedas/vatu_vanuatu_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::VatuVanuatu do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/won_coreia_norte_spec.rb
+++ b/spec/moedas/won_coreia_norte_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::WonCoreiaNorte do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/won_coreia_sul_spec.rb
+++ b/spec/moedas/won_coreia_sul_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::WonCoreiaSul do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/xelim_quenia_spec.rb
+++ b/spec/moedas/xelim_quenia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::XelimQuenia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/xelim_somalia_spec.rb
+++ b/spec/moedas/xelim_somalia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::XelimSomalia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/xelim_tanzania_spec.rb
+++ b/spec/moedas/xelim_tanzania_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::XelimTanzania do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/xelim_uganda_spec.rb
+++ b/spec/moedas/xelim_uganda_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::XelimUganda do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/moedas/zloty_polonia_spec.rb
+++ b/spec/moedas/zloty_polonia_spec.rb
@@ -65,8 +65,4 @@ describe BrCotacao::ZlotyPolonia do
       end
     end
   end
-
-  describe '.cotacao_agora' do
-    it_should_behave_like 'cotacao tempo real', :cotacao_agora
-  end
 end

--- a/spec/shared_tests/moedas.rb
+++ b/spec/shared_tests/moedas.rb
@@ -35,31 +35,3 @@ shared_examples_for 'dia com cotacao' do |metodo|
     subject.send(metodo, data_pesquisada).should eq(valor_esperado)
   end
 end
-
-shared_examples_for 'cotacao tempo real' do |metodo|
-  context 'sistema de cotação não está funcionando' do
-    let(:erro)   { BrCotacao::Errors::CotacaoAgoraNaoEncontradaError }
-
-    before do
-      Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'ERROR'))
-    end
-
-    it 'deve lançar um erro' do
-      expect { subject.send metodo }.to raise_error erro
-    end
-  end
-
-  context 'sistema de cotação está funcionando' do
-    before do
-      Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => "MOEDA1 to MOEDA2,0.9426,11/1/2013,11:33am"))
-    end
-
-    it "deve retornar a cotacao em um hash" do
-      subject.send(metodo)[:compra].should eql(0.9426)
-    end
-
-    it "deve retornar a data em um hash" do
-      subject.send(metodo)[:data].should eql(Time.parse('2013-11-01 11:33am -0400'))
-    end
-  end
-end


### PR DESCRIPTION
Neste PR, remove `cotacao_agora`, pois o serviço do Yahoo Finanças deixou de funcionar.