### PR TITLE
Ajuste na chamada do endereço para buscar a cotação de um determinado dia

### DIFF
--- a/lib/brcotacao/moedas.rb
+++ b/lib/brcotacao/moedas.rb
@@ -12,7 +12,7 @@ module BrCotacao
   # Licença:: GPL
   module Moeda
 
-    FONTE_INFORMACAO            = 'http://www4.bcb.gov.br/Download/fechamento/'.freeze
+    FONTE_INFORMACAO            = 'https://www4.bcb.gov.br/Download/fechamento/'.freeze
     FONTE_INFORMACAO_TEMPO_REAL = 'http://download.finance.yahoo.com/d/quotes.body?'
 
     POSICAO_CODIGO_MOEDA = 1
@@ -94,9 +94,9 @@ module BrCotacao
 
     def busca_dados(data_pesquisa)
       arquivo_baixar       = data_pesquisa.strftime("%Y%m%d.csv")
-      endereco             = URI.parse(FONTE_INFORMACAO + arquivo_baixar)
-      conexao              = Net::HTTP.new(endereco.host)
-      cotacoes             = conexao.get(endereco.path)
+      endereco             = URI(FONTE_INFORMACAO + arquivo_baixar)
+      cotacoes             = Net::HTTP.get_response(endereco)
+
       raise BrCotacao::Errors::CotacaoNaoEncontradaError.new(data_pesquisa) unless cotacoes.msg.eql? 'OK'
 
       cotacoes.body

--- a/spec/moedas/afegane_afeganist_spec.rb
+++ b/spec/moedas/afegane_afeganist_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::AfeganeAfeganist do
         let(:valor_esperado) { {:compra => 0.03728, :venda => 0.0373} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::AfeganeAfeganist do
         let(:valor_esperado) { 0.03728 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::AfeganeAfeganist do
         let(:valor_esperado) { 0.0373 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/ariary_madagascar_spec.rb
+++ b/spec/moedas/ariary_madagascar_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::AriaryMadagascar do
         let(:valor_esperado) { {:compra => 0.0008569, :venda => 0.0008691} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::AriaryMadagascar do
         let(:valor_esperado) { 0.0008569 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::AriaryMadagascar do
         let(:valor_esperado) { 0.0008691 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/balboa_panama_spec.rb
+++ b/spec/moedas/balboa_panama_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::BalboaPanama do
         let(:valor_esperado) { {:compra => 1.8123, :venda => 1.813} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::BalboaPanama do
         let(:valor_esperado) { 1.8123 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::BalboaPanama do
         let(:valor_esperado) { 1.813 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/bath_tailandia_spec.rb
+++ b/spec/moedas/bath_tailandia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::BathTailandia do
         let(:valor_esperado) { {:compra => 0.05859, :venda => 0.05865} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::BathTailandia do
         let(:valor_esperado) { 0.05859 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::BathTailandia do
         let(:valor_esperado) { 0.05865 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/birr_etiopia_spec.rb
+++ b/spec/moedas/birr_etiopia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::BirrEtiopia do
         let(:valor_esperado) { {:compra => 0.1038, :venda => 0.1061} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::BirrEtiopia do
         let(:valor_esperado) { 0.1038 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::BirrEtiopia do
         let(:valor_esperado) { 0.1061 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/bolivar_forte_ven_spec.rb
+++ b/spec/moedas/bolivar_forte_ven_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::BolivarForteVen do
         let(:valor_esperado) { {:compra => 0.4215, :venda => 0.4227} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::BolivarForteVen do
         let(:valor_esperado) { 0.4215 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::BolivarForteVen do
         let(:valor_esperado) { 0.4227 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/boliviano_bolivia_spec.rb
+++ b/spec/moedas/boliviano_bolivia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::BolivianoBolivia do
         let(:valor_esperado) { {:compra => 0.2613, :venda => 0.2614} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::BolivianoBolivia do
         let(:valor_esperado) { 0.2613 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::BolivianoBolivia do
         let(:valor_esperado) { 0.2614 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/cedi_gana_spec.rb
+++ b/spec/moedas/cedi_gana_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::CediGana do
         let(:valor_esperado) { {:compra => 1.1, :venda => 1.1035} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::CediGana do
         let(:valor_esperado) { 1.1 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::CediGana do
         let(:valor_esperado) { 1.1035 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/colon_costa_rica_spec.rb
+++ b/spec/moedas/colon_costa_rica_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::ColonCostaRica do
         let(:valor_esperado) { {:compra => 0.003532, :venda => 0.003684} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::ColonCostaRica do
         let(:valor_esperado) { 0.003532 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::ColonCostaRica do
         let(:valor_esperado) { 0.003684 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/colon_el_salvador_spec.rb
+++ b/spec/moedas/colon_el_salvador_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::ColonElSalvador do
         let(:valor_esperado) { {:compra => 0.2071, :venda => 0.2072} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::ColonElSalvador do
         let(:valor_esperado) { 0.2071 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::ColonElSalvador do
         let(:valor_esperado) { 0.2072 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/cordoba_ouro_spec.rb
+++ b/spec/moedas/cordoba_ouro_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::CordobaOuro do
         let(:valor_esperado) { {:compra => 0.07911, :venda => 0.07914} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::CordobaOuro do
         let(:valor_esperado) { 0.07911 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::CordobaOuro do
         let(:valor_esperado) { 0.07914 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/coroa_dinam_dinam_spec.rb
+++ b/spec/moedas/coroa_dinam_dinam_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::CoroaDinamDinam do
         let(:valor_esperado) { {:compra => 0.3259, :venda => 0.326} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::CoroaDinamDinam do
         let(:valor_esperado) { 0.3259 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::CoroaDinamDinam do
         let(:valor_esperado) { 0.326 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/coroa_islnd_islan_spec.rb
+++ b/spec/moedas/coroa_islnd_islan_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::CoroaIslndIslan do
         let(:valor_esperado) { {:compra => 0.01521, :venda => 0.01525} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::CoroaIslndIslan do
         let(:valor_esperado) { 0.01521 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::CoroaIslndIslan do
         let(:valor_esperado) { 0.01525 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/coroa_norue_norue_spec.rb
+++ b/spec/moedas/coroa_norue_norue_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::CoroaNorueNorue do
         let(:valor_esperado) { {:compra => 0.3152, :venda => 0.3156} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::CoroaNorueNorue do
         let(:valor_esperado) { 0.3152 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::CoroaNorueNorue do
         let(:valor_esperado) { 0.3156 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/coroa_sueca_sueci_spec.rb
+++ b/spec/moedas/coroa_sueca_sueci_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::CoroaSuecaSueci do
         let(:valor_esperado) { {:compra => 0.2687, :venda => 0.2689} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::CoroaSuecaSueci do
         let(:valor_esperado) { 0.2687 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::CoroaSuecaSueci do
         let(:valor_esperado) { 0.2689 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/coroa_tcheca_spec.rb
+++ b/spec/moedas/coroa_tcheca_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::CoroaTcheca do
         let(:valor_esperado) { {:compra => 0.09508, :venda => 0.09524} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::CoroaTcheca do
         let(:valor_esperado) { 0.09508 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::CoroaTcheca do
         let(:valor_esperado) { 0.09524 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dalasi_gambia_spec.rb
+++ b/spec/moedas/dalasi_gambia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DalasiGambia do
         let(:valor_esperado) { {:compra => 0.06131, :venda => 0.06366} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DalasiGambia do
         let(:valor_esperado) { 0.06131 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DalasiGambia do
         let(:valor_esperado) { 0.06366 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_argelino_spec.rb
+++ b/spec/moedas/dinar_argelino_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarArgelino do
         let(:valor_esperado) { {:compra => 0.02387, :venda => 0.02486} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarArgelino do
         let(:valor_esperado) { 0.02387 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarArgelino do
         let(:valor_esperado) { 0.02486 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_bahrein_spec.rb
+++ b/spec/moedas/dinar_bahrein_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarBahrein do
         let(:valor_esperado) { {:compra => 4.8072, :venda => 4.809} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarBahrein do
         let(:valor_esperado) { 4.8072 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarBahrein do
         let(:valor_esperado) { 4.809 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_iraque_spec.rb
+++ b/spec/moedas/dinar_iraque_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarIraque do
         let(:valor_esperado) { {:compra => 0.00155, :venda => 0.001551} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarIraque do
         let(:valor_esperado) { 0.00155 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarIraque do
         let(:valor_esperado) { 0.001551 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_jordania_spec.rb
+++ b/spec/moedas/dinar_jordania_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarJordania do
         let(:valor_esperado) { {:compra => 2.5525, :venda => 2.5571} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarJordania do
         let(:valor_esperado) { 2.5525 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarJordania do
         let(:valor_esperado) { 2.5571 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_kwait_spec.rb
+++ b/spec/moedas/dinar_kwait_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarKwait do
         let(:valor_esperado) { {:compra => 6.5167, :venda => 6.5665} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarKwait do
         let(:valor_esperado) { 6.5167 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarKwait do
         let(:valor_esperado) { 6.5665 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_libia_spec.rb
+++ b/spec/moedas/dinar_libia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarLibia do
         let(:valor_esperado) { {:compra => 1.4494, :venda => 1.4675} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarLibia do
         let(:valor_esperado) { 1.4494 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarLibia do
         let(:valor_esperado) { 1.4675 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_macedonia_spec.rb
+++ b/spec/moedas/dinar_macedonia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarMacedonia do
         let(:valor_esperado) { {:compra => 0.03894, :venda => 0.03953} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarMacedonia do
         let(:valor_esperado) { 0.03894 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarMacedonia do
         let(:valor_esperado) { 0.03953 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_servio_serv_spec.rb
+++ b/spec/moedas/dinar_servio_serv_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarServioServ do
         let(:valor_esperado) { {:compra => 0.02342, :venda => 0.02361} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarServioServ do
         let(:valor_esperado) { 0.02342 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarServioServ do
         let(:valor_esperado) { 0.02361 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dinar_tunisia_spec.rb
+++ b/spec/moedas/dinar_tunisia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DinarTunisia do
         let(:valor_esperado) { {:compra => 1.2201, :venda => 1.2289} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DinarTunisia do
         let(:valor_esperado) { 1.2201 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DinarTunisia do
         let(:valor_esperado) { 1.2289 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/direito_especial_spec.rb
+++ b/spec/moedas/direito_especial_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DireitoEspecial do
         let(:valor_esperado) { {:compra => 2.8223, :venda => 2.8234} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DireitoEspecial do
         let(:valor_esperado) { 2.8223 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DireitoEspecial do
         let(:valor_esperado) { 2.8234 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dirham_emir_arabe_spec.rb
+++ b/spec/moedas/dirham_emir_arabe_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DirhamEmirArabe do
         let(:valor_esperado) { {:compra => 0.4934, :venda => 0.4936} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DirhamEmirArabe do
         let(:valor_esperado) { 0.4934 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DirhamEmirArabe do
         let(:valor_esperado) { 0.4936 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dirham_marrocos_spec.rb
+++ b/spec/moedas/dirham_marrocos_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DirhamMarrocos do
         let(:valor_esperado) { {:compra => 0.2162, :venda => 0.2171} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DirhamMarrocos do
         let(:valor_esperado) { 0.2162 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DirhamMarrocos do
         let(:valor_esperado) { 0.2171 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dobra_s_tome_prin_spec.rb
+++ b/spec/moedas/dobra_s_tome_prin_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DobraSTomePrin do
         let(:valor_esperado) { {:compra => 0.0001002, :venda => 0.0001002} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DobraSTomePrin do
         let(:valor_esperado) { 0.0001002 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DobraSTomePrin do
         let(:valor_esperado) { 0.0001002 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_australiano_spec.rb
+++ b/spec/moedas/dolar_australiano_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarAustraliano do
         let(:valor_esperado) { {:compra => 1.8402, :venda => 1.8411} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarAustraliano do
         let(:valor_esperado) { 1.8402 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarAustraliano do
         let(:valor_esperado) { 1.8411 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_bahamas_spec.rb
+++ b/spec/moedas/dolar_bahamas_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarBahamas do
         let(:valor_esperado) { {:compra => 1.8123, :venda => 1.813} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarBahamas do
         let(:valor_esperado) { 1.8123 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarBahamas do
         let(:valor_esperado) { 1.813 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_barbados_spec.rb
+++ b/spec/moedas/dolar_barbados_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarBarbados do
         let(:valor_esperado) { {:compra => 0.9062, :venda => 0.9065} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarBarbados do
         let(:valor_esperado) { 0.9062 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarBarbados do
         let(:valor_esperado) { 0.9065 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_belize_spec.rb
+++ b/spec/moedas/dolar_belize_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarBelize do
         let(:valor_esperado) { {:compra => 0.9147, :venda => 0.9151} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarBelize do
         let(:valor_esperado) { 0.9147 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarBelize do
         let(:valor_esperado) { 0.9151 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_bermudas_spec.rb
+++ b/spec/moedas/dolar_bermudas_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarBermudas do
         let(:valor_esperado) { {:compra => 1.8123, :venda => 1.813} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarBermudas do
         let(:valor_esperado) { 1.8123 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarBermudas do
         let(:valor_esperado) { 1.813 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_brunei_spec.rb
+++ b/spec/moedas/dolar_brunei_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarBrunei do
         let(:valor_esperado) { {:compra => 1.3975, :venda => 1.3992} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarBrunei do
         let(:valor_esperado) { 1.3975 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarBrunei do
         let(:valor_esperado) { 1.3992 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_canadense_spec.rb
+++ b/spec/moedas/dolar_canadense_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarCanadense do
         let(:valor_esperado) { {:compra => 1.7717, :venda => 1.7726} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarCanadense do
         let(:valor_esperado) { 1.7717 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarCanadense do
         let(:valor_esperado) { 1.7726 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_caribe_orie_spec.rb
+++ b/spec/moedas/dolar_caribe_orie_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarCaribeOrie do
         let(:valor_esperado) { {:compra => 0.6712, :venda => 0.6715} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarCaribeOrie do
         let(:valor_esperado) { 0.6712 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarCaribeOrie do
         let(:valor_esperado) { 0.6715 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_cayman_spec.rb
+++ b/spec/moedas/dolar_cayman_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarCayman do
         let(:valor_esperado) { {:compra => 2.2101, :venda => 2.211} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarCayman do
         let(:valor_esperado) { 2.2101 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarCayman do
         let(:valor_esperado) { 2.211 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_cingapura_spec.rb
+++ b/spec/moedas/dolar_cingapura_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarCingapura do
         let(:valor_esperado) { {:compra => 1.3977, :venda => 1.3989} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarCingapura do
         let(:valor_esperado) { 1.3977 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarCingapura do
         let(:valor_esperado) { 1.3989 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_da_guiana_spec.rb
+++ b/spec/moedas/dolar_da_guiana_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarDaGuiana do
         let(:valor_esperado) { {:compra => 0.00884, :venda => 0.008844} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarDaGuiana do
         let(:valor_esperado) { 0.00884 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarDaGuiana do
         let(:valor_esperado) { 0.008844 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_da_namibia_spec.rb
+++ b/spec/moedas/dolar_da_namibia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarDaNamibia do
         let(:valor_esperado) { {:compra => 0.2227, :venda => 0.223} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarDaNamibia do
         let(:valor_esperado) { 0.2227 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarDaNamibia do
         let(:valor_esperado) { 0.223 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_dos_eua_spec.rb
+++ b/spec/moedas/dolar_dos_eua_spec.rb
@@ -18,7 +18,7 @@ describe BrCotacao::DolarDosEua do
         let(:valor_esperado) { {:compra => 1.8123, :venda => 1.813} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -39,7 +39,7 @@ describe BrCotacao::DolarDosEua do
         let(:valor_esperado) { 1.8123 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -60,7 +60,7 @@ describe BrCotacao::DolarDosEua do
         let(:valor_esperado) { 1.813 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_fiji_spec.rb
+++ b/spec/moedas/dolar_fiji_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarFiji do
         let(:valor_esperado) { {:compra => 0.9815, :venda => 0.9819} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarFiji do
         let(:valor_esperado) { 0.9815 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarFiji do
         let(:valor_esperado) { 0.9819 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_hong_kong_spec.rb
+++ b/spec/moedas/dolar_hong_kong_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarHongKong do
         let(:valor_esperado) { {:compra => 0.2329, :venda => 0.233} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarHongKong do
         let(:valor_esperado) { 0.2329 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarHongKong do
         let(:valor_esperado) { 0.233 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_il_salomao_spec.rb
+++ b/spec/moedas/dolar_il_salomao_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarIlSalomao do
         let(:valor_esperado) { {:compra => 0.2399, :venda => 0.2609} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarIlSalomao do
         let(:valor_esperado) { 0.2399 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarIlSalomao do
         let(:valor_esperado) { 0.2609 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_jamaica_spec.rb
+++ b/spec/moedas/dolar_jamaica_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarJamaica do
         let(:valor_esperado) { {:compra => 0.02092, :venda => 0.02118} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarJamaica do
         let(:valor_esperado) { 0.02092 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarJamaica do
         let(:valor_esperado) { 0.02118 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_liberia_spec.rb
+++ b/spec/moedas/dolar_liberia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarLiberia do
         let(:valor_esperado) { {:compra => 0.02517, :venda => 0.02518} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarLiberia do
         let(:valor_esperado) { 0.02517 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarLiberia do
         let(:valor_esperado) { 0.02518 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_nova_zeland_spec.rb
+++ b/spec/moedas/dolar_nova_zeland_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarNovaZeland do
         let(:valor_esperado) { {:compra => 1.3975, :venda => 1.3985} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarNovaZeland do
         let(:valor_esperado) { 1.3975 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarNovaZeland do
         let(:valor_esperado) { 1.3985 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_ouro_spec.rb
+++ b/spec/moedas/dolar_ouro_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarOuro do
         let(:valor_esperado) { {:compra => 99.7413, :venda => 99.7799} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarOuro do
         let(:valor_esperado) { 99.7413 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarOuro do
         let(:valor_esperado) { 99.7799 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_suriname_spec.rb
+++ b/spec/moedas/dolar_suriname_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarSuriname do
         let(:valor_esperado) { {:compra => 0.541, :venda => 0.5578} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarSuriname do
         let(:valor_esperado) { 0.541 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarSuriname do
         let(:valor_esperado) { 0.5578 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_trin_tobag_spec.rb
+++ b/spec/moedas/dolar_trin_tobag_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarTrinTobag do
         let(:valor_esperado) { {:compra => 0.2814, :venda => 0.2901} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarTrinTobag do
         let(:valor_esperado) { 0.2814 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarTrinTobag do
         let(:valor_esperado) { 0.2901 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dolar_zimbabue_spec.rb
+++ b/spec/moedas/dolar_zimbabue_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DolarZimbabue do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DolarZimbabue do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DolarZimbabue do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dongue_vietnan_spec.rb
+++ b/spec/moedas/dongue_vietnan_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DongueVietnan do
         let(:valor_esperado) { {:compra => 8.63e-05, :venda => 8.63e-05} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DongueVietnan do
         let(:valor_esperado) { 8.63e-05 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DongueVietnan do
         let(:valor_esperado) { 8.63e-05 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/dram_armenia_rep_spec.rb
+++ b/spec/moedas/dram_armenia_rep_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::DramArmeniaRep do
         let(:valor_esperado) { {:compra => 0.004732, :venda => 0.004745} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::DramArmeniaRep do
         let(:valor_esperado) { 0.004732 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::DramArmeniaRep do
         let(:valor_esperado) { 0.004745 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/escudo_cabo_verde_spec.rb
+++ b/spec/moedas/escudo_cabo_verde_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::EscudoCaboVerde do
         let(:valor_esperado) { {:compra => 0.022, :venda => 0.02201} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::EscudoCaboVerde do
         let(:valor_esperado) { 0.022 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::EscudoCaboVerde do
         let(:valor_esperado) { 0.02201 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/euro_spec.rb
+++ b/spec/moedas/euro_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::Euro do
         let(:valor_esperado) { {:compra => 2.423, :venda => 2.4242} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::Euro do
         let(:valor_esperado) { 2.423 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::Euro do
         let(:valor_esperado) { 2.4242 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/florim_aruba_spec.rb
+++ b/spec/moedas/florim_aruba_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FlorimAruba do
         let(:valor_esperado) { {:compra => 1.0125, :venda => 1.0128} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FlorimAruba do
         let(:valor_esperado) { 1.0125 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FlorimAruba do
         let(:valor_esperado) { 1.0128 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/forint_hungria_spec.rb
+++ b/spec/moedas/forint_hungria_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::ForintHungria do
         let(:valor_esperado) { {:compra => 0.007961, :venda => 0.007975} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::ForintHungria do
         let(:valor_esperado) { 0.007961 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::ForintHungria do
         let(:valor_esperado) { 0.007975 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_burundi_spec.rb
+++ b/spec/moedas/franco_burundi_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoBurundi do
         let(:valor_esperado) { {:compra => 0.001342, :venda => 0.001365} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoBurundi do
         let(:valor_esperado) { 0.001342 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoBurundi do
         let(:valor_esperado) { 0.001365 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_cfa_bceao_spec.rb
+++ b/spec/moedas/franco_cfa_bceao_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoCfaBceao do
         let(:valor_esperado) { {:compra => 0.003683, :venda => 0.003686} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoCfaBceao do
         let(:valor_esperado) { 0.003683 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoCfaBceao do
         let(:valor_esperado) { 0.003686 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_cfa_beac_spec.rb
+++ b/spec/moedas/franco_cfa_beac_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoCfaBeac do
         let(:valor_esperado) { {:compra => 0.003683, :venda => 0.003686} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoCfaBeac do
         let(:valor_esperado) { 0.003683 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoCfaBeac do
         let(:valor_esperado) { 0.003686 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_cfp_spec.rb
+++ b/spec/moedas/franco_cfp_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoCfp do
         let(:valor_esperado) { {:compra => 0.02032, :venda => 0.02034} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoCfp do
         let(:valor_esperado) { 0.02032 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoCfp do
         let(:valor_esperado) { 0.02034 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_comores_spec.rb
+++ b/spec/moedas/franco_comores_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoComores do
         let(:valor_esperado) { {:compra => 0.004911, :venda => 0.004914} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoComores do
         let(:valor_esperado) { 0.004911 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoComores do
         let(:valor_esperado) { 0.004914 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_congoles_spec.rb
+++ b/spec/moedas/franco_congoles_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoCongoles do
         let(:valor_esperado) { {:compra => 0.002025, :venda => 0.002025} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoCongoles do
         let(:valor_esperado) { 0.002025 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoCongoles do
         let(:valor_esperado) { 0.002025 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_djibuti_spec.rb
+++ b/spec/moedas/franco_djibuti_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoDjibuti do
         let(:valor_esperado) { {:compra => 0.0102, :venda => 0.0102} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoDjibuti do
         let(:valor_esperado) { 0.0102 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoDjibuti do
         let(:valor_esperado) { 0.0102 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_guine_spec.rb
+++ b/spec/moedas/franco_guine_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoGuine do
         let(:valor_esperado) { {:compra => 0.00025, :venda => 0.0002536} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoGuine do
         let(:valor_esperado) { 0.00025 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoGuine do
         let(:valor_esperado) { 0.0002536 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_ruanda_spec.rb
+++ b/spec/moedas/franco_ruanda_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoRuanda do
         let(:valor_esperado) { {:compra => 0.00301, :venda => 0.003011} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoRuanda do
         let(:valor_esperado) { 0.00301 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoRuanda do
         let(:valor_esperado) { 0.003011 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/franco_suico_spec.rb
+++ b/spec/moedas/franco_suico_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::FrancoSuico do
         let(:valor_esperado) { {:compra => 1.9618, :venda => 1.9628} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::FrancoSuico do
         let(:valor_esperado) { 1.9618 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::FrancoSuico do
         let(:valor_esperado) { 1.9628 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/gourde_haiti_spec.rb
+++ b/spec/moedas/gourde_haiti_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::GourdeHaiti do
         let(:valor_esperado) { {:compra => 0.04411, :venda => 0.04579} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::GourdeHaiti do
         let(:valor_esperado) { 0.04411 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::GourdeHaiti do
         let(:valor_esperado) { 0.04579 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/guarani_paraguai_spec.rb
+++ b/spec/moedas/guarani_paraguai_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::GuaraniParaguai do
         let(:valor_esperado) { {:compra => 0.0004077, :venda => 0.0004144} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::GuaraniParaguai do
         let(:valor_esperado) { 0.0004077 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::GuaraniParaguai do
         let(:valor_esperado) { 0.0004144 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/guilder_antilhas_spec.rb
+++ b/spec/moedas/guilder_antilhas_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::GuilderAntilhas do
         let(:valor_esperado) { {:compra => 1.0125, :venda => 1.0128} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::GuilderAntilhas do
         let(:valor_esperado) { 1.0125 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::GuilderAntilhas do
         let(:valor_esperado) { 1.0128 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/hyrvnia_ucrania_spec.rb
+++ b/spec/moedas/hyrvnia_ucrania_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::HyrvniaUcrania do
         let(:valor_esperado) { {:compra => 0.2261, :venda => 0.2267} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::HyrvniaUcrania do
         let(:valor_esperado) { 0.2261 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::HyrvniaUcrania do
         let(:valor_esperado) { 0.2267 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/iene_spec.rb
+++ b/spec/moedas/iene_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::Iene do
         let(:valor_esperado) { {:compra => 0.02333, :venda => 0.02335} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::Iene do
         let(:valor_esperado) { 0.02333 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::Iene do
         let(:valor_esperado) { 0.02335 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/iuan_renmimbi_chi_spec.rb
+++ b/spec/moedas/iuan_renmimbi_chi_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::IuanRenmimbiChi do
         let(:valor_esperado) { {:compra => 0.2847, :venda => 0.2849} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::IuanRenmimbiChi do
         let(:valor_esperado) { 0.2847 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::IuanRenmimbiChi do
         let(:valor_esperado) { 0.2849 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/kina_papua_n_guin_spec.rb
+++ b/spec/moedas/kina_papua_n_guin_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::KinaPapuaNGuin do
         let(:valor_esperado) { {:compra => 0.8164, :venda => 0.8766} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::KinaPapuaNGuin do
         let(:valor_esperado) { 0.8164 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::KinaPapuaNGuin do
         let(:valor_esperado) { 0.8766 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/kuna_croacia_spec.rb
+++ b/spec/moedas/kuna_croacia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::KunaCroacia do
         let(:valor_esperado) { {:compra => 0.3224, :venda => 0.3238} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::KunaCroacia do
         let(:valor_esperado) { 0.3224 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::KunaCroacia do
         let(:valor_esperado) { 0.3238 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/kwanza_angola_spec.rb
+++ b/spec/moedas/kwanza_angola_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::KwanzaAngola do
         let(:valor_esperado) { {:compra => 0.01912, :venda => 0.01912} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::KwanzaAngola do
         let(:valor_esperado) { 0.01912 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::KwanzaAngola do
         let(:valor_esperado) { 0.01912 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/lari_georgia_spec.rb
+++ b/spec/moedas/lari_georgia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LariGeorgia do
         let(:valor_esperado) { {:compra => 1.0885, :venda => 1.0988} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LariGeorgia do
         let(:valor_esperado) { 1.0885 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LariGeorgia do
         let(:valor_esperado) { 1.0988 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/lat_letonia_rep_spec.rb
+++ b/spec/moedas/lat_letonia_rep_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LatLetoniaRep do
         let(:valor_esperado) { {:compra => 3.4652, :venda => 3.4765} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LatLetoniaRep do
         let(:valor_esperado) { 3.4652 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LatLetoniaRep do
         let(:valor_esperado) { 3.4765 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/lek_albania_rep_spec.rb
+++ b/spec/moedas/lek_albania_rep_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LekAlbaniaRep do
         let(:valor_esperado) { {:compra => 0.01731, :venda => 0.01745} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LekAlbaniaRep do
         let(:valor_esperado) { 0.01731 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LekAlbaniaRep do
         let(:valor_esperado) { 0.01745 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/lempira_honduras_spec.rb
+++ b/spec/moedas/lempira_honduras_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LempiraHonduras do
         let(:valor_esperado) { {:compra => 0.09579, :venda => 0.09582} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LempiraHonduras do
         let(:valor_esperado) { 0.09579 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LempiraHonduras do
         let(:valor_esperado) { 0.09582 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/leone_serra_leoa_spec.rb
+++ b/spec/moedas/leone_serra_leoa_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LeoneSerraLeoa do
         let(:valor_esperado) { {:compra => 0.0004087, :venda => 0.0004171} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LeoneSerraLeoa do
         let(:valor_esperado) { 0.0004087 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LeoneSerraLeoa do
         let(:valor_esperado) { 0.0004171 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/leu_moldavia_rep_spec.rb
+++ b/spec/moedas/leu_moldavia_rep_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LeuMoldaviaRep do
         let(:valor_esperado) { {:compra => 0.1536, :venda => 0.1547} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LeuMoldaviaRep do
         let(:valor_esperado) { 0.1536 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LeuMoldaviaRep do
         let(:valor_esperado) { 0.1547 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/lev_bulgaria_rep_spec.rb
+++ b/spec/moedas/lev_bulgaria_rep_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LevBulgariaRep do
         let(:valor_esperado) { {:compra => 1.2384, :venda => 1.2391} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LevBulgariaRep do
         let(:valor_esperado) { 1.2384 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LevBulgariaRep do
         let(:valor_esperado) { 1.2391 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/libra_egito_spec.rb
+++ b/spec/moedas/libra_egito_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LibraEgito do
         let(:valor_esperado) { {:compra => 0.3008, :venda => 0.3019} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LibraEgito do
         let(:valor_esperado) { 0.3008 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LibraEgito do
         let(:valor_esperado) { 0.3019 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/libra_esterlina_spec.rb
+++ b/spec/moedas/libra_esterlina_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LibraEsterlina do
         let(:valor_esperado) { {:compra => 2.8341, :venda => 2.8354} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LibraEsterlina do
         let(:valor_esperado) { 2.8341 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LibraEsterlina do
         let(:valor_esperado) { 2.8354 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/libra_falkland_spec.rb
+++ b/spec/moedas/libra_falkland_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LibraFalkland do
         let(:valor_esperado) { {:compra => 2.8343, :venda => 2.8357} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LibraFalkland do
         let(:valor_esperado) { 2.8343 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LibraFalkland do
         let(:valor_esperado) { 2.8357 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/libra_gibraltar_spec.rb
+++ b/spec/moedas/libra_gibraltar_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LibraGibraltar do
         let(:valor_esperado) { {:compra => 2.8341, :venda => 2.8354} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LibraGibraltar do
         let(:valor_esperado) { 2.8341 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LibraGibraltar do
         let(:valor_esperado) { 2.8354 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/libra_libano_spec.rb
+++ b/spec/moedas/libra_libano_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LibraLibano do
         let(:valor_esperado) { {:compra => 0.0012, :venda => 0.001208} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LibraLibano do
         let(:valor_esperado) { 0.0012 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LibraLibano do
         let(:valor_esperado) { 0.001208 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/libra_siria_rep_spec.rb
+++ b/spec/moedas/libra_siria_rep_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LibraSiriaRep do
         let(:valor_esperado) { {:compra => 0.03347, :venda => 0.03348} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LibraSiriaRep do
         let(:valor_esperado) { 0.03347 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LibraSiriaRep do
         let(:valor_esperado) { 0.03348 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/libra_sta_helena_spec.rb
+++ b/spec/moedas/libra_sta_helena_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LibraStaHelena do
         let(:valor_esperado) { {:compra => 2.8339, :venda => 2.8354} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LibraStaHelena do
         let(:valor_esperado) { 2.8339 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LibraStaHelena do
         let(:valor_esperado) { 2.8354 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/lilangeni_suazil_spec.rb
+++ b/spec/moedas/lilangeni_suazil_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LilangeniSuazil do
         let(:valor_esperado) { {:compra => 0.2227, :venda => 0.223} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LilangeniSuazil do
         let(:valor_esperado) { 0.2227 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LilangeniSuazil do
         let(:valor_esperado) { 0.223 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/lita_lituania_spec.rb
+++ b/spec/moedas/lita_lituania_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LitaLituania do
         let(:valor_esperado) { {:compra => 0.7015, :venda => 0.7019} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LitaLituania do
         let(:valor_esperado) { 0.7015 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LitaLituania do
         let(:valor_esperado) { 0.7019 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/loti_lesoto_spec.rb
+++ b/spec/moedas/loti_lesoto_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::LotiLesoto do
         let(:valor_esperado) { {:compra => 0.2228, :venda => 0.223} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::LotiLesoto do
         let(:valor_esperado) { 0.2228 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::LotiLesoto do
         let(:valor_esperado) { 0.223 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/manat_arzebaijao_spec.rb
+++ b/spec/moedas/manat_arzebaijao_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::ManatArzebaijao do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::ManatArzebaijao do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::ManatArzebaijao do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/marco_conv_bosnia_spec.rb
+++ b/spec/moedas/marco_conv_bosnia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::MarcoConvBosnia do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::MarcoConvBosnia do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::MarcoConvBosnia do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/naira_nigeria_spec.rb
+++ b/spec/moedas/naira_nigeria_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NairaNigeria do
         let(:valor_esperado) { {:compra => 0.01119, :venda => 0.01122} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NairaNigeria do
         let(:valor_esperado) { 0.01119 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NairaNigeria do
         let(:valor_esperado) { 0.01122 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/nakfa_eritreia_spec.rb
+++ b/spec/moedas/nakfa_eritreia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NakfaEritreia do
         let(:valor_esperado) { {:compra => 0.1208, :venda => 0.1209} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NakfaEritreia do
         let(:valor_esperado) { 0.1208 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NakfaEritreia do
         let(:valor_esperado) { 0.1209 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/ngultrum_butao_spec.rb
+++ b/spec/moedas/ngultrum_butao_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NgultrumButao do
         let(:valor_esperado) { {:compra => 0.03482, :venda => 0.03484} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NgultrumButao do
         let(:valor_esperado) { 0.03482 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NgultrumButao do
         let(:valor_esperado) { 0.03484 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/nova_libra_sudane_spec.rb
+++ b/spec/moedas/nova_libra_sudane_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NovaLibraSudane do
         let(:valor_esperado) { {:compra => 0.6663, :venda => 0.6867} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NovaLibraSudane do
         let(:valor_esperado) { 0.6663 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NovaLibraSudane do
         let(:valor_esperado) { 0.6867 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/nova_lira_turquia_spec.rb
+++ b/spec/moedas/nova_lira_turquia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NovaLiraTurquia do
         let(:valor_esperado) { {:compra => 0.9812, :venda => 0.982} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NovaLiraTurquia do
         let(:valor_esperado) { 0.9812 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NovaLiraTurquia do
         let(:valor_esperado) { 0.982 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/nova_metical_moca_spec.rb
+++ b/spec/moedas/nova_metical_moca_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NovaMeticalMoca do
         let(:valor_esperado) { {:compra => 0.06755, :venda => 0.06894} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NovaMeticalMoca do
         let(:valor_esperado) { 0.06755 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NovaMeticalMoca do
         let(:valor_esperado) { 0.06894 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/novo_dolar_taiwan_spec.rb
+++ b/spec/moedas/novo_dolar_taiwan_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NovoDolarTaiwan do
         let(:valor_esperado) { {:compra => 0.05998, :venda => 0.06003} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NovoDolarTaiwan do
         let(:valor_esperado) { 0.05998 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NovoDolarTaiwan do
         let(:valor_esperado) { 0.06003 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/novo_leu_romenia_spec.rb
+++ b/spec/moedas/novo_leu_romenia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NovoLeuRomenia do
         let(:valor_esperado) { {:compra => 0.5575, :venda => 0.5583} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NovoLeuRomenia do
         let(:valor_esperado) { 0.5575 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NovoLeuRomenia do
         let(:valor_esperado) { 0.5583 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/novo_manat_turcom_spec.rb
+++ b/spec/moedas/novo_manat_turcom_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NovoManatTurcom do
         let(:valor_esperado) { {:compra => 0.6359, :venda => 0.6361} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NovoManatTurcom do
         let(:valor_esperado) { 0.6359 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NovoManatTurcom do
         let(:valor_esperado) { 0.6361 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/novo_sol_peru_spec.rb
+++ b/spec/moedas/novo_sol_peru_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::NovoSolPeru do
         let(:valor_esperado) { {:compra => 0.672, :venda => 0.6743} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::NovoSolPeru do
         let(:valor_esperado) { 0.672 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::NovoSolPeru do
         let(:valor_esperado) { 0.6743 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/paanga_tonga_spec.rb
+++ b/spec/moedas/paanga_tonga_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PaangaTonga do
         let(:valor_esperado) { {:compra => 1.0551, :venda => 1.0555} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PaangaTonga do
         let(:valor_esperado) { 1.0551 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PaangaTonga do
         let(:valor_esperado) { 1.0555 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/pataca_macau_spec.rb
+++ b/spec/moedas/pataca_macau_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PatacaMacau do
         let(:valor_esperado) { {:compra => 0.2263, :venda => 0.2264} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PatacaMacau do
         let(:valor_esperado) { 0.2263 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PatacaMacau do
         let(:valor_esperado) { 0.2264 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_argentina_spec.rb
+++ b/spec/moedas/peso_argentina_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoArgentina do
         let(:valor_esperado) { {:compra => 0.4236, :venda => 0.4237} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoArgentina do
         let(:valor_esperado) { 0.4236 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoArgentina do
         let(:valor_esperado) { 0.4237 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_chile_spec.rb
+++ b/spec/moedas/peso_chile_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoChile do
         let(:valor_esperado) { {:compra => 0.003548, :venda => 0.003552} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoChile do
         let(:valor_esperado) { 0.003548 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoChile do
         let(:valor_esperado) { 0.003552 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_colombia_spec.rb
+++ b/spec/moedas/peso_colombia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoColombia do
         let(:valor_esperado) { {:compra => 0.0009392, :venda => 0.0009402} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoColombia do
         let(:valor_esperado) { 0.0009392 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoColombia do
         let(:valor_esperado) { 0.0009402 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_cuba_spec.rb
+++ b/spec/moedas/peso_cuba_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoCuba do
         let(:valor_esperado) { {:compra => 1.8123, :venda => 1.813} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoCuba do
         let(:valor_esperado) { 1.8123 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoCuba do
         let(:valor_esperado) { 1.813 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_filipinas_spec.rb
+++ b/spec/moedas/peso_filipinas_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoFilipinas do
         let(:valor_esperado) { {:compra => 0.04152, :venda => 0.04165} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoFilipinas do
         let(:valor_esperado) { 0.04152 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoFilipinas do
         let(:valor_esperado) { 0.04165 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_guine_bissau_spec.rb
+++ b/spec/moedas/peso_guine_bissau_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoGuineBissau do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoGuineBissau do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoGuineBissau do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_mexico_spec.rb
+++ b/spec/moedas/peso_mexico_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoMexico do
         let(:valor_esperado) { {:compra => 0.1327, :venda => 0.1327} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoMexico do
         let(:valor_esperado) { 0.1327 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoMexico do
         let(:valor_esperado) { 0.1327 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_rep_dominic_spec.rb
+++ b/spec/moedas/peso_rep_dominic_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoRepDominic do
         let(:valor_esperado) { {:compra => 0.04695, :venda => 0.04715} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoRepDominic do
         let(:valor_esperado) { 0.04695 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoRepDominic do
         let(:valor_esperado) { 0.04715 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/peso_uruguaio_spec.rb
+++ b/spec/moedas/peso_uruguaio_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PesoUruguaio do
         let(:valor_esperado) { {:compra => 0.09084, :venda => 0.09226} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PesoUruguaio do
         let(:valor_esperado) { 0.09084 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PesoUruguaio do
         let(:valor_esperado) { 0.09226 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/pula_botswana_spec.rb
+++ b/spec/moedas/pula_botswana_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::PulaBotswana do
         let(:valor_esperado) { {:compra => 0.2412, :venda => 0.2422} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::PulaBotswana do
         let(:valor_esperado) { 0.2412 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::PulaBotswana do
         let(:valor_esperado) { 0.2422 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/quacha_malavi_spec.rb
+++ b/spec/moedas/quacha_malavi_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::QuachaMalavi do
         let(:valor_esperado) { {:compra => 0.01084, :venda => 0.01111} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::QuachaMalavi do
         let(:valor_esperado) { 0.01084 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::QuachaMalavi do
         let(:valor_esperado) { 0.01111 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/quacha_zambia_spec.rb
+++ b/spec/moedas/quacha_zambia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::QuachaZambia do
         let(:valor_esperado) { {:compra => 0.0003547, :venda => 0.0003562} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::QuachaZambia do
         let(:valor_esperado) { 0.0003547 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::QuachaZambia do
         let(:valor_esperado) { 0.0003562 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/quetzal_guatemala_spec.rb
+++ b/spec/moedas/quetzal_guatemala_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::QuetzalGuatemala do
         let(:valor_esperado) { {:compra => 0.2322, :venda => 0.2338} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::QuetzalGuatemala do
         let(:valor_esperado) { 0.2322 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::QuetzalGuatemala do
         let(:valor_esperado) { 0.2338 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/quiate_birmania_spec.rb
+++ b/spec/moedas/quiate_birmania_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::QuiateBirmania do
         let(:valor_esperado) { {:compra => 0.2823, :venda => 0.2824} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::QuiateBirmania do
         let(:valor_esperado) { 0.2823 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::QuiateBirmania do
         let(:valor_esperado) { 0.2824 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/quipe_laos_rep_spec.rb
+++ b/spec/moedas/quipe_laos_rep_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::QuipeLaosRep do
         let(:valor_esperado) { {:compra => 0.0002262, :venda => 0.0002262} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::QuipeLaosRep do
         let(:valor_esperado) { 0.0002262 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::QuipeLaosRep do
         let(:valor_esperado) { 0.0002262 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rande_africa_sul_spec.rb
+++ b/spec/moedas/rande_africa_sul_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RandeAfricaSul do
         let(:valor_esperado) { {:compra => 0.2228, :venda => 0.223} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RandeAfricaSul do
         let(:valor_esperado) { 0.2228 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RandeAfricaSul do
         let(:valor_esperado) { 0.223 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/real_brasil_spec.rb
+++ b/spec/moedas/real_brasil_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RealBrasil do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RealBrasil do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RealBrasil do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rial_arab_saudita_spec.rb
+++ b/spec/moedas/rial_arab_saudita_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RialArabSaudita do
         let(:valor_esperado) { {:compra => 0.4832, :venda => 0.4834} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RialArabSaudita do
         let(:valor_esperado) { 0.4832 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RialArabSaudita do
         let(:valor_esperado) { 0.4834 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rial_catar_spec.rb
+++ b/spec/moedas/rial_catar_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RialCatar do
         let(:valor_esperado) { {:compra => 0.4976, :venda => 0.4979} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RialCatar do
         let(:valor_esperado) { 0.4976 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RialCatar do
         let(:valor_esperado) { 0.4979 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rial_iemen_spec.rb
+++ b/spec/moedas/rial_iemen_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RialIemen do
         let(:valor_esperado) { {:compra => 0.008256, :venda => 0.008317} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RialIemen do
         let(:valor_esperado) { 0.008256 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RialIemen do
         let(:valor_esperado) { 0.008317 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rial_iran_rep_spec.rb
+++ b/spec/moedas/rial_iran_rep_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RialIranRep do
         let(:valor_esperado) { {:compra => 0.0001634, :venda => 0.0001692} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RialIranRep do
         let(:valor_esperado) { 0.0001634 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RialIranRep do
         let(:valor_esperado) { 0.0001692 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rial_oma_spec.rb
+++ b/spec/moedas/rial_oma_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RialOma do
         let(:valor_esperado) { {:compra => 4.7061, :venda => 4.7201} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RialOma do
         let(:valor_esperado) { 4.7061 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RialOma do
         let(:valor_esperado) { 4.7201 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/riel_camboja_spec.rb
+++ b/spec/moedas/riel_camboja_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RielCamboja do
         let(:valor_esperado) { {:compra => 0.0004494, :venda => 0.0004496} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RielCamboja do
         let(:valor_esperado) { 0.0004494 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RielCamboja do
         let(:valor_esperado) { 0.0004496 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/ringgit_malasia_spec.rb
+++ b/spec/moedas/ringgit_malasia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RinggitMalasia do
         let(:valor_esperado) { {:compra => 0.5757, :venda => 0.5761} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RinggitMalasia do
         let(:valor_esperado) { 0.5757 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RinggitMalasia do
         let(:valor_esperado) { 0.5761 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rublo_belarus_spec.rb
+++ b/spec/moedas/rublo_belarus_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RubloBelarus do
         let(:valor_esperado) { {:compra => 0.0002071, :venda => 0.0002108} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RubloBelarus do
         let(:valor_esperado) { 0.0002071 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RubloBelarus do
         let(:valor_esperado) { 0.0002108 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rublo_russia_spec.rb
+++ b/spec/moedas/rublo_russia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RubloRussia do
         let(:valor_esperado) { {:compra => 0.05758, :venda => 0.05766} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RubloRussia do
         let(:valor_esperado) { 0.05758 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RubloRussia do
         let(:valor_esperado) { 0.05766 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rufia_maldivas_spec.rb
+++ b/spec/moedas/rufia_maldivas_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RufiaMaldivas do
         let(:valor_esperado) { {:compra => 0.1184, :venda => 0.1184} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RufiaMaldivas do
         let(:valor_esperado) { 0.1184 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RufiaMaldivas do
         let(:valor_esperado) { 0.1184 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rupia_india_spec.rb
+++ b/spec/moedas/rupia_india_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RupiaIndia do
         let(:valor_esperado) { {:compra => 0.03482, :venda => 0.03484} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RupiaIndia do
         let(:valor_esperado) { 0.03482 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RupiaIndia do
         let(:valor_esperado) { 0.03484 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rupia_indonesia_spec.rb
+++ b/spec/moedas/rupia_indonesia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RupiaIndonesia do
         let(:valor_esperado) { {:compra => 0.0002, :venda => 0.0002006} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RupiaIndonesia do
         let(:valor_esperado) { 0.0002 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RupiaIndonesia do
         let(:valor_esperado) { 0.0002006 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rupia_mauricio_spec.rb
+++ b/spec/moedas/rupia_mauricio_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RupiaMauricio do
         let(:valor_esperado) { {:compra => 0.06185, :venda => 0.0622} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RupiaMauricio do
         let(:valor_esperado) { 0.06185 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RupiaMauricio do
         let(:valor_esperado) { 0.0622 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rupia_nepal_spec.rb
+++ b/spec/moedas/rupia_nepal_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RupiaNepal do
         let(:valor_esperado) { {:compra => 0.02188, :venda => 0.02189} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RupiaNepal do
         let(:valor_esperado) { 0.02188 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RupiaNepal do
         let(:valor_esperado) { 0.02189 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rupia_paquistao_spec.rb
+++ b/spec/moedas/rupia_paquistao_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RupiaPaquistao do
         let(:valor_esperado) { {:compra => 0.02034, :venda => 0.02035} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RupiaPaquistao do
         let(:valor_esperado) { 0.02034 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RupiaPaquistao do
         let(:valor_esperado) { 0.02035 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rupia_seycheles_spec.rb
+++ b/spec/moedas/rupia_seycheles_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RupiaSeycheles do
         let(:valor_esperado) { {:compra => 0.1306, :venda => 0.1465} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RupiaSeycheles do
         let(:valor_esperado) { 0.1306 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RupiaSeycheles do
         let(:valor_esperado) { 0.1465 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/rupia_sri_lanka_spec.rb
+++ b/spec/moedas/rupia_sri_lanka_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::RupiaSriLanka do
         let(:valor_esperado) { {:compra => 0.01592, :venda => 0.01596} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::RupiaSriLanka do
         let(:valor_esperado) { 0.01592 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::RupiaSriLanka do
         let(:valor_esperado) { 0.01596 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/shekel_israel_spec.rb
+++ b/spec/moedas/shekel_israel_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::ShekelIsrael do
         let(:valor_esperado) { {:compra => 0.4813, :venda => 0.4826} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::ShekelIsrael do
         let(:valor_esperado) { 0.4813 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::ShekelIsrael do
         let(:valor_esperado) { 0.4826 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/som_quirguistao_spec.rb
+++ b/spec/moedas/som_quirguistao_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::SomQuirguistao do
         let(:valor_esperado) { {:compra => 0.03888, :venda => 0.0389} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::SomQuirguistao do
         let(:valor_esperado) { 0.03888 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::SomQuirguistao do
         let(:valor_esperado) { 0.0389 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/som_uzbequistao_spec.rb
+++ b/spec/moedas/som_uzbequistao_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::SomUzbequistao do
         let(:valor_esperado) { {:compra => 0.001016, :venda => 0.001017} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::SomUzbequistao do
         let(:valor_esperado) { 0.001016 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::SomUzbequistao do
         let(:valor_esperado) { 0.001017 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/somoni_tadjiquist_spec.rb
+++ b/spec/moedas/somoni_tadjiquist_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::SomoniTadjiquist do
         let(:valor_esperado) { {:compra => 0.3808, :venda => 0.381} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::SomoniTadjiquist do
         let(:valor_esperado) { 0.3808 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::SomoniTadjiquist do
         let(:valor_esperado) { 0.381 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/taca_bangladesh_spec.rb
+++ b/spec/moedas/taca_bangladesh_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::TacaBangladesh do
         let(:valor_esperado) { {:compra => 0.02345, :venda => 0.02348} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::TacaBangladesh do
         let(:valor_esperado) { 0.02345 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::TacaBangladesh do
         let(:valor_esperado) { 0.02348 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/tala_samoa_oc_spec.rb
+++ b/spec/moedas/tala_samoa_oc_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::TalaSamoaOc do
         let(:valor_esperado) { {:compra => 4.171, :venda => 4.3425} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::TalaSamoaOc do
         let(:valor_esperado) { 4.171 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::TalaSamoaOc do
         let(:valor_esperado) { 4.3425 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/tenge_cazaquistao_spec.rb
+++ b/spec/moedas/tenge_cazaquistao_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::TengeCazaquistao do
         let(:valor_esperado) { {:compra => 0.01229, :venda => 0.0123} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::TengeCazaquistao do
         let(:valor_esperado) { 0.01229 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::TengeCazaquistao do
         let(:valor_esperado) { 0.0123 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/tugrik_mongolia_spec.rb
+++ b/spec/moedas/tugrik_mongolia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::TugrikMongolia do
         let(:valor_esperado) { {:compra => 0.001305, :venda => 0.001324} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::TugrikMongolia do
         let(:valor_esperado) { 0.001305 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::TugrikMongolia do
         let(:valor_esperado) { 0.001324 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/unid_fomento_chil_spec.rb
+++ b/spec/moedas/unid_fomento_chil_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::UnidFomentoChil do
         let(:valor_esperado) { {:compra => 8.15e-05, :venda => 8.15e-05} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::UnidFomentoChil do
         let(:valor_esperado) { 8.15e-05 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::UnidFomentoChil do
         let(:valor_esperado) { 8.15e-05 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/unid_monet_europ_spec.rb
+++ b/spec/moedas/unid_monet_europ_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::UnidMonetEurop do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::UnidMonetEurop do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::UnidMonetEurop do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/vatu_vanuatu_spec.rb
+++ b/spec/moedas/vatu_vanuatu_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::VatuVanuatu do
         let(:valor_esperado) { {:compra => 0.01909, :venda => 0.01909} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::VatuVanuatu do
         let(:valor_esperado) { 0.01909 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::VatuVanuatu do
         let(:valor_esperado) { 0.01909 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/won_coreia_norte_spec.rb
+++ b/spec/moedas/won_coreia_norte_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::WonCoreiaNorte do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::WonCoreiaNorte do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::WonCoreiaNorte do
         let(:valor_esperado) { nil }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/won_coreia_sul_spec.rb
+++ b/spec/moedas/won_coreia_sul_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::WonCoreiaSul do
         let(:valor_esperado) { {:compra => 0.00158, :venda => 0.001581} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::WonCoreiaSul do
         let(:valor_esperado) { 0.00158 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::WonCoreiaSul do
         let(:valor_esperado) { 0.001581 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/xelim_quenia_spec.rb
+++ b/spec/moedas/xelim_quenia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::XelimQuenia do
         let(:valor_esperado) { {:compra => 0.02026, :venda => 0.02029} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::XelimQuenia do
         let(:valor_esperado) { 0.02026 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::XelimQuenia do
         let(:valor_esperado) { 0.02029 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/xelim_somalia_spec.rb
+++ b/spec/moedas/xelim_somalia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::XelimSomalia do
         let(:valor_esperado) { {:compra => 0.001115, :venda => 0.001116} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::XelimSomalia do
         let(:valor_esperado) { 0.001115 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::XelimSomalia do
         let(:valor_esperado) { 0.001116 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/xelim_tanzania_spec.rb
+++ b/spec/moedas/xelim_tanzania_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::XelimTanzania do
         let(:valor_esperado) { {:compra => 0.001105, :venda => 0.001133} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::XelimTanzania do
         let(:valor_esperado) { 0.001105 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::XelimTanzania do
         let(:valor_esperado) { 0.001133 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/xelim_uganda_spec.rb
+++ b/spec/moedas/xelim_uganda_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::XelimUganda do
         let(:valor_esperado) { {:compra => 0.0007352, :venda => 0.0007385} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::XelimUganda do
         let(:valor_esperado) { 0.0007352 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::XelimUganda do
         let(:valor_esperado) { 0.0007385 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/moedas/zloty_polonia_spec.rb
+++ b/spec/moedas/zloty_polonia_spec.rb
@@ -16,7 +16,7 @@ describe BrCotacao::ZlotyPolonia do
         let(:valor_esperado) { {:compra => 0.5365, :venda => 0.537} }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :cotacao
@@ -37,7 +37,7 @@ describe BrCotacao::ZlotyPolonia do
         let(:valor_esperado) { 0.5365 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :compra
@@ -58,7 +58,7 @@ describe BrCotacao::ZlotyPolonia do
         let(:valor_esperado) { 0.537 }
 
         before do
-          Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
+          Net::HTTP.stub(:get_response).and_return(double(:msg => 'OK', :body => fixure('20111209.csv')))
         end
 
         it_should_behave_like 'dia com cotacao', :venda

--- a/spec/shared_tests/moedas.rb
+++ b/spec/shared_tests/moedas.rb
@@ -12,7 +12,7 @@ shared_examples_for 'banco central fora' do |metodo|
     let(:data_pesquisada) { Date.new(2011, 12, 10) }
 
     before do
-     Net::HTTP.any_instance.stub(:get).and_raise(SocketError)
+     Net::HTTP.stub(:get_response).and_raise(SocketError)
     end
 
     it_should_behave_like 'lanca erro', metodo, Exception
@@ -22,7 +22,7 @@ end
 shared_examples_for 'dia sem cotacao' do |metodo|
   context "mas a moeda nao tem cotação no dia procurado" do
     before do
-       Net::HTTP.any_instance.stub(:get).and_return(double(:msg => 'fail', :body => ''))
+       Net::HTTP.stub(:get_response).and_return(double(:msg => 'fail', :body => ''))
     end
     let(:data_pesquisada) { Date.new(2011, 12, 10) }
     it_should_behave_like 'lanca erro', metodo, BrCotacao::Errors::CotacaoNaoEncontradaError


### PR DESCRIPTION
Este PR, faz um ajuste na chamada para pegar os dados de cotação para um determinado dia.
Anteriormente o retorno da requisição era diferente de `OK` retornando sempre um status code `302` um objeto `NET::HTTPFound`, lançando sempre uma exceção `BrCotacao::Errors::CotacaoNaoEncontradaError`